### PR TITLE
Fix: resolve symlinks when computing FLEET_ROOT (closes #3)

### DIFF
--- a/bin/fleet
+++ b/bin/fleet
@@ -22,7 +22,7 @@ if [ "${BASH_VERSINFO[0]}" -lt 4 ] 2>/dev/null; then
 fi
 
 # ── Resolve install directory ───────────────────────────────────────────────
-FLEET_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FLEET_ROOT="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.." && pwd)"
 
 # ── Load core libraries ────────────────────────────────────────────────────
 source "$FLEET_ROOT/lib/core/config.sh"


### PR DESCRIPTION
## Summary

`bin/fleet:25` computed `FLEET_ROOT` from `${BASH_SOURCE[0]}` directly. When the script was invoked through the `~/.local/bin/fleet` symlink that `fleet init` creates as documented in `_meta.json` and the README, `dirname/..` resolved to the symlink's parent (`~/.local`) instead of the install root. Every subsequent `source "$FLEET_ROOT/lib/..."` then failed with `No such file or directory`, leaving the CLI unusable from PATH after a vanilla install.

This change wraps `${BASH_SOURCE[0]}` in `realpath`, which is already used at `bin/fleet:17` for the same kind of resolution.

```diff
-FLEET_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FLEET_ROOT="$(cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.." && pwd)"
```

## Test plan

- [x] Before patch: `git clone … ~/.local/share/fleet && ~/.local/share/fleet/bin/fleet init && fleet --version` fails with `lib/core/config.sh: No such file or directory`
- [x] After patch: same flow → `fleet --version` correctly prints `fleet v3.0.4`, `fleet agents` runs, all `source` lines resolve
- [x] Direct invocation via the absolute path still works (no regression for the no-symlink case)

Fixes #3.